### PR TITLE
Adding cmake configuration to download roc-toolkit with branch provided via cmake variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
           cmake -DDOWNLOAD_ROC=OFF .. && make -j
           test -e ../bin/rt-tests
 
-  ubuntu-roc-custom-path:
+  ubuntu-roc-custom-path-roc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,7 +62,9 @@ jobs:
       - name: Build tests
         run: |
           mkdir build && cd build
-          cmake -DDOWNLOAD_ROC=OFF .. && make -j
+          cmake -DDOWNLOAD_ROC=OFF \
+           -DROC_INCLUDE_DIR=/tmp/roc/output/include
+           -DROC_LIB_DIR=/tmp/roc/output/lib .. && make -j
           test -e ../bin/rt-tests
 
   ubuntu-download-roc:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ on:
     - cron: '0 0 * * 1'
 
 jobs:
-  ubuntu:
+  ubuntu-systemwide-roc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,6 +33,31 @@ jobs:
           git clone https://github.com/roc-streaming/roc-toolkit.git /tmp/roc
           scons -C /tmp/roc -Q --build-3rdparty=openfec
           sudo scons -C /tmp/roc -Q --build-3rdparty=openfec install
+
+      - name: Build tests
+        run: |
+          mkdir build && cd build
+          cmake -DDOWNLOAD_ROC=OFF .. && make -j
+          test -e ../bin/rt-tests
+
+  ubuntu-roc-custom-path:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install g++ pkg-config scons ragel gengetopt \
+            libuv1-dev libunwind-dev libpulse-dev libsox-dev libcpputest-dev libspeexdsp-dev \
+            libtool intltool autoconf automake make cmake
+
+      - name: Build Roc
+        run: |
+          git clone https://github.com/roc-streaming/roc-toolkit.git /tmp/roc
+          scons -C /tmp/roc -Q --build-3rdparty=openfec --prefix=/tmp/roc/output
+          sudo scons -C /tmp/roc -Q --build-3rdparty=openfec --prefix=/tmp/roc/output install
 
       - name: Build tests
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,5 +36,25 @@ jobs:
 
       - name: Build tests
         run: |
-          make build
+          mkdir build && cd build
+          cmake -DDOWNLOAD_ROC=OFF .. && make -j
+          test -e ./bin/rt-tests
+
+  ubuntu-download-roc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install g++ pkg-config scons ragel gengetopt \
+            libuv1-dev libunwind-dev libpulse-dev libsox-dev libcpputest-dev libspeexdsp-dev \
+            libtool intltool autoconf automake make cmake
+
+      - name: Build tests
+        run: |
+          mkdir build && cd build
+          cmake .. && make -j
           test -e ./bin/rt-tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DDOWNLOAD_ROC=OFF .. && make -j
-          test -e ./bin/rt-tests
+          test -e ../bin/rt-tests
 
   ubuntu-download-roc:
     runs-on: ubuntu-latest
@@ -57,4 +57,4 @@ jobs:
         run: |
           mkdir build && cd build
           cmake .. && make -j
-          test -e ./bin/rt-tests
+          test -e ../bin/rt-tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DDOWNLOAD_ROC=OFF \
-           -DROC_INCLUDE_DIR=/tmp/roc/output/include
+           -DROC_INCLUDE_DIR=/tmp/roc/output/include \
            -DROC_LIB_DIR=/tmp/roc/output/lib .. && make -j
           test -e ../bin/rt-tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ define_option(DOWNLOAD_ROC ON BOOL "automatically download and build roc-toolkit
 if(DOWNLOAD_ROC)
   define_option(ROC_BRANCH "master" STRING "roc-toolkit branch")
   include("cmake/download_roc.cmake")
+  add_custom_target(download_roc DEPENDS RocLibrary)
 else()
+  add_custom_target(download_roc) # download_roc an empty target in this case
   if(NOT ROC_INCLUDE_DIR STREQUAL "")
     get_filename_component(ROC_INCLUDE_DIR "${ROC_INCLUDE_DIR}" ABSOLUTE)
     message(STATUS "Using ROC_INCLUDE_DIR - ${ROC_INCLUDE_DIR}")
@@ -56,7 +58,7 @@ add_executable(rt-tests
   tests/test_service_quality.cpp
 )
 
-add_dependencies(rt-tests googletest RocLibrary)
+add_dependencies(rt-tests googletest download_roc)
 
 find_package(Threads)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rt-tests)
 
-include(ExternalProject)
-
-ExternalProject_Add(googletest
-  GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.12.1
-  GIT_SHALLOW       ON
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
-  LOG_DOWNLOAD      ON
-  LOG_BUILD         ON
-)
-
 include("cmake/define_option.cmake")
+include("cmake/download_googletest.cmake")
 
 define_option(ROC_INCLUDE_DIR "" STRING "roc toolkit include directory")
 define_option(ROC_LIB_DIR "" STRING "roc toolkit library directory")
@@ -41,16 +28,6 @@ else()
 
   link_libraries("roc")
 endif()
-
-include_directories(
-  "${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include"
-  #"${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/src/public_api/include"
-)
-
-link_directories(
-  "${CMAKE_CURRENT_BINARY_DIR}/googletest-build/lib"
-  #"${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/bin/x86_64-pc-linux-gnu/"
-)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -78,14 +55,15 @@ add_executable(rt-tests
   tests/test_service_quality.cpp
 )
 
-add_dependencies(rt-tests googletest roc)
+add_dependencies(rt-tests googletest RocLibrary)
 
 find_package(Threads)
 
 target_link_libraries(rt-tests
-  -l:libroc.a
+  roc
   gtest
   gtest_main
+  ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT})
 
 add_custom_command(TARGET rt-tests POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,28 @@ ExternalProject_Add(googletest
   LOG_BUILD         ON
 )
 
+set(ROC_TOOLKIT_BRANCH master)
+
+ExternalProject_Add(roc-toolkit
+  GIT_REPOSITORY    https://github.com/roc-streaming/roc-toolkit.git
+  GIT_TAG           origin/${ROC_TOOLKIT_BRANCH}
+  GIT_SHALLOW       ON
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src"
+  BUILD_COMMAND     scons -Q --build-3rdparty=openfec -C "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src"
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  CONFIGURE_COMMAND ""
+  LOG_DOWNLOAD      ON
+)
+
 include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include"
+  "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/src/public_api/include"
 )
 
 link_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/googletest-build/lib"
+  "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/bin/x86_64-pc-linux-gnu/"
 )
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,28 +16,40 @@ ExternalProject_Add(googletest
   LOG_BUILD         ON
 )
 
-set(ROC_TOOLKIT_BRANCH master)
+include("cmake/define_option.cmake")
 
-ExternalProject_Add(roc-toolkit
-  GIT_REPOSITORY    https://github.com/roc-streaming/roc-toolkit.git
-  GIT_TAG           origin/${ROC_TOOLKIT_BRANCH}
-  GIT_SHALLOW       ON
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src"
-  BUILD_COMMAND     scons -Q --build-3rdparty=openfec -C "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src"
-  INSTALL_COMMAND   ""
-  TEST_COMMAND      ""
-  CONFIGURE_COMMAND ""
-  LOG_DOWNLOAD      ON
-)
+define_option(ROC_INCLUDE_DIR "" STRING "roc toolkit include directory")
+define_option(ROC_LIB_DIR "" STRING "roc toolkit library directory")
+define_option(DOWNLOAD_ROC ON BOOL "automatically download and build roc-toolkit")
+
+if(DOWNLOAD_ROC)
+  include("cmake/download_roc.cmake")
+else()
+  if(NOT ROC_INCLUDE_DIR STREQUAL "")
+    get_filename_component(ROC_INCLUDE_DIR "${ROC_INCLUDE_DIR}" ABSOLUTE)
+    message(STATUS "Using ROC_INCLUDE_DIR - ${ROC_INCLUDE_DIR}")
+
+    include_directories(SYSTEM "${ROC_INCLUDE_DIR}")
+  endif()
+
+  if(NOT ROC_LIB_DIR STREQUAL "")
+    get_filename_component(ROC_LIB_DIR "${ROC_LIB_DIR}" ABSOLUTE)
+    message(STATUS "Using ROC_LIB_DIR - ${ROC_LIB_DIR}")
+
+    link_directories("${ROC_LIB_DIR}")
+  endif()
+
+  link_libraries("roc")
+endif()
 
 include_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include"
-  "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/src/public_api/include"
+  #"${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/src/public_api/include"
 )
 
 link_directories(
   "${CMAKE_CURRENT_BINARY_DIR}/googletest-build/lib"
-  "${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/bin/x86_64-pc-linux-gnu/"
+  #"${CMAKE_CURRENT_BINARY_DIR}/roc-toolkit-src/bin/x86_64-pc-linux-gnu/"
 )
 
 set(CMAKE_CXX_STANDARD 17)
@@ -66,12 +78,12 @@ add_executable(rt-tests
   tests/test_service_quality.cpp
 )
 
-add_dependencies(rt-tests googletest)
+add_dependencies(rt-tests googletest roc)
 
 find_package(Threads)
 
 target_link_libraries(rt-tests
-  roc
+  -l:libroc.a
   gtest
   gtest_main
   ${CMAKE_THREAD_LIBS_INIT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ define_option(ROC_LIB_DIR "" STRING "roc toolkit library directory")
 define_option(DOWNLOAD_ROC ON BOOL "automatically download and build roc-toolkit")
 
 if(DOWNLOAD_ROC)
+  define_option(ROC_BRANCH "master" STRING "roc-toolkit branch")
   include("cmake/download_roc.cmake")
 else()
   if(NOT ROC_INCLUDE_DIR STREQUAL "")

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Requirements
 * C++17 compiler
 * CMake >= 3.0.0
 * Google Test >= 1.10 (downloaded automatically)
-* Roc Toolkit (should be pre-installed system-wide, see [instructions](https://roc-streaming.org/toolkit/docs/building/user_cookbook.html))
+* Roc Toolkit (downloaded automatically)
 
 Instructions
 ------------
@@ -60,6 +60,13 @@ Format code:
 
 ```
 make fmt
+```
+
+Specify **roc-toolkit** branch:
+
+```
+mkdir build && cd build
+cmake -D ROC_TOOLKIT_BRANCH=master .. && make
 ```
 
 Workflow

--- a/README.md
+++ b/README.md
@@ -68,23 +68,26 @@ Next build and run:
 make
 ```
 
-Clean build results:
-
-```
-make clean
-```
-
-Format code:
-
-```
-make fmt
-```
-
 To specify **roc-toolkit** branch use cmake flag `ROC_TOOLKIT_BRANCH`
 
 ```
 mkdir build && cd build
 cmake -DROC_TOOLKIT_BRANCH=master .. && make
+```
+### Additional targets
+
+You can accomplish these additional tasks using the following targets.
+
+To clean working build directory:
+
+```
+make clean
+```
+
+To format code:
+
+```
+make fmt
 ```
 
 ### Advanced bulid

--- a/README.md
+++ b/README.md
@@ -51,15 +51,11 @@ First install build tools:
 
 ```
 sudo apt install -y \
-    gcc g++ \
-    make \
-    libtool intltool m4 autoconf automake \
-    meson libsndfile-dev \
-    cmake \
-    scons \
-    git \
-    wget \
-    python3
+    g++ pkg-config scons ragel gengetopt \
+      libuv1-dev libunwind-dev \
+      libpulse-dev libsox-dev \
+      libcpputest-dev libspeexdsp-dev \
+      libtool intltool autoconf automake make cmake
 ```
 
 Next build and run:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,25 @@ Requirements
 Instructions
 ------------
 
-Build and run:
+### Simple build
+When using this method, CMake will automatically download and build dependencies (Roc Toolkit). Roc will be statically linked into the modules and there is no need to install it into the system.
+
+First install build tools:
+
+```
+sudo apt install -y \
+    gcc g++ \
+    make \
+    libtool intltool m4 autoconf automake \
+    meson libsndfile-dev \
+    cmake \
+    scons \
+    git \
+    wget \
+    python3
+```
+
+Next build and run:
 
 ```
 make
@@ -62,12 +80,27 @@ Format code:
 make fmt
 ```
 
-Specify **roc-toolkit** branch:
+To specify **roc-toolkit** branch use cmake flag `ROC_TOOLKIT_BRANCH`
 
 ```
 mkdir build && cd build
-cmake -D ROC_TOOLKIT_BRANCH=master .. && make
+cmake -DROC_TOOLKIT_BRANCH=master .. && make
 ```
+
+### Advanced bulid
+
+You can disable automatic downloading of roc-toolkit and build it manually.
+
+Download, build and install Roc Toolkit into the system as described on [this page](https://roc-streaming.org/toolkit/docs/building/user_cookbook.html)
+
+```
+mkdir build && cd build
+cmake -DDOWNLOAD_ROC=OFF .. && make
+```
+To provide custom path to roc-toolkit library and headers use flags
+`ROC_INCLUDE_DIR` and `ROC_LIB_DIR`
+
+
 
 Workflow
 --------

--- a/cmake/define_option.cmake
+++ b/cmake/define_option.cmake
@@ -1,0 +1,22 @@
+# A custom function to create an option for the user which 
+# can be set via environment or provided via cmdline.
+# It can be boolean or string
+# Order of precedence
+# 1. Command line
+# 2. Environment variable
+# 3. Default specified in cmake
+
+macro(define_option ARG_NAME ARG_DEFAULT ARG_TYPE ARG_HELP)
+  # overwrite default from environment
+  set(DEFAULT_VALUE $ENV{${ARG_NAME}})
+  if(NOT DEFAULT_VALUE)
+    set(DEFAULT_VALUE "${ARG_DEFAULT}")
+  endif()
+
+  # register option
+  if(${ARG_TYPE} STREQUAL "BOOL")
+    option(${ARG_NAME} "${ARG_HELP}" "${DEFAULT_VALUE}")
+  elseif(${ARG_TYPE} STREQUAL "STRING")
+    set(${ARG_NAME} "${DEFAULT_VALUE}" CACHE STRING "${ARG_HELP}")
+  endif()
+endmacro()

--- a/cmake/download_googletest.cmake
+++ b/cmake/download_googletest.cmake
@@ -1,0 +1,21 @@
+include(ExternalProject)
+
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           release-1.12.1
+  GIT_SHALLOW       ON
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+  LOG_DOWNLOAD      ON
+  LOG_BUILD         ON
+)
+
+include_directories(
+  "${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include"
+)
+
+link_directories(
+  "${CMAKE_CURRENT_BINARY_DIR}/googletest-build/lib"
+)

--- a/cmake/download_roc.cmake
+++ b/cmake/download_roc.cmake
@@ -29,7 +29,7 @@ set(SCONS_CMD
 
 define_option(ROC_TOOLKIT_BRANCH "master" STRING "roc-toolkit branch")
 
-ExternalProject_Add(roc
+ExternalProject_Add(RocLibrary
   GIT_REPOSITORY "https://github.com/roc-streaming/roc-toolkit.git"
   GIT_TAG origin/${ROC_TOOLKIT_BRANCH}
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/roc-src"

--- a/cmake/download_roc.cmake
+++ b/cmake/download_roc.cmake
@@ -1,0 +1,57 @@
+include(ExternalProject)
+
+if(DEFINED ENV{CI})
+  set(USE_LOGFILES OFF)
+else()
+  set(USE_LOGFILES ON)
+endif()
+
+set(SCONS_CMD
+  scons
+  --prefix=${CMAKE_CURRENT_BINARY_DIR}/roc-prefix
+  --build-3rdparty=all
+  --enable-static
+  --disable-shared
+  --disable-tools
+  --disable-sox
+  --disable-openssl
+  --disable-libunwind
+  --disable-pulseaudio
+  #--host=${CMAKE_CXX_COMPILER_TARGET}
+  #"CC=${CMAKE_C_COMPILER}"
+  #"CCLD=${CMAKE_C_COMPILER}"
+  #"CXX=${CMAKE_CXX_COMPILER}"
+  #"CXXLD=${CMAKE_CXX_COMPILER}"
+  #"AR=${CMAKE_AR}"
+  #"RANLIB=${CMAKE_RANLIB}"
+  #"STRIP=${CMAKE_STRIP}"
+)  
+
+define_option(ROC_TOOLKIT_BRANCH "master" STRING "roc-toolkit branch")
+
+ExternalProject_Add(roc
+  GIT_REPOSITORY "https://github.com/roc-streaming/roc-toolkit.git"
+  GIT_TAG origin/${ROC_TOOLKIT_BRANCH}
+  SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/roc-src"
+  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/roc-prefix"
+  BUILD_IN_SOURCE ON
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ${SCONS_CMD}
+  INSTALL_COMMAND ${SCONS_CMD} install
+  TEST_COMMAND ""
+  LOG_DOWNLOAD ${USE_LOGFILES}
+  LOG_PATCH ${USE_LOGFILES}
+  LOG_CONFIGURE ${USE_LOGFILES}
+  LOG_BUILD ${USE_LOGFILES}
+  LOG_INSTALL ${USE_LOGFILES}
+  LOG_TEST ${USE_LOGFILES}
+  )
+
+
+include_directories(
+  "${CMAKE_CURRENT_BINARY_DIR}/roc-prefix/include"
+)
+
+link_directories(
+   "${CMAKE_CURRENT_BINARY_DIR}/roc-prefix/lib/"
+)

--- a/cmake/download_roc.cmake
+++ b/cmake/download_roc.cmake
@@ -17,14 +17,14 @@ set(SCONS_CMD
   --disable-openssl
   --disable-libunwind
   --disable-pulseaudio
-  #--host=${CMAKE_CXX_COMPILER_TARGET}
-  #"CC=${CMAKE_C_COMPILER}"
-  #"CCLD=${CMAKE_C_COMPILER}"
-  #"CXX=${CMAKE_CXX_COMPILER}"
-  #"CXXLD=${CMAKE_CXX_COMPILER}"
-  #"AR=${CMAKE_AR}"
-  #"RANLIB=${CMAKE_RANLIB}"
-  #"STRIP=${CMAKE_STRIP}"
+  --host=${CMAKE_CXX_COMPILER_TARGET}
+  "CC=${CMAKE_C_COMPILER}"
+  "CCLD=${CMAKE_C_COMPILER}"
+  "CXX=${CMAKE_CXX_COMPILER}"
+  "CXXLD=${CMAKE_CXX_COMPILER}"
+  "AR=${CMAKE_AR}"
+  "RANLIB=${CMAKE_RANLIB}"
+  "STRIP=${CMAKE_STRIP}"
 )  
 
 

--- a/cmake/download_roc.cmake
+++ b/cmake/download_roc.cmake
@@ -27,11 +27,10 @@ set(SCONS_CMD
   #"STRIP=${CMAKE_STRIP}"
 )  
 
-define_option(ROC_TOOLKIT_BRANCH "master" STRING "roc-toolkit branch")
 
 ExternalProject_Add(RocLibrary
   GIT_REPOSITORY "https://github.com/roc-streaming/roc-toolkit.git"
-  GIT_TAG origin/${ROC_TOOLKIT_BRANCH}
+  GIT_TAG origin/${ROC_BRANCH}
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/roc-src"
   INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/roc-prefix"
   BUILD_IN_SOURCE ON


### PR DESCRIPTION
## Summary

fixes #9 task: "Download and build roc-toolkit instead of using system-wide installation. Allow to specify branch/ref
"